### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/python-stripzip
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Build package
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      # the publishing uses PyPI's trusted publishing, so configured on pypi instead of using secrets
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and publish the package to PyPI on releases
- configure the workflow to use PyPI trusted publishing for this project

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918b460c66c83229fa8c61a0ee0554c)