### PR TITLE
Remove Codacy badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|PyPi Package| |Build Status| |Codacy Rating| |Coverage Report|
+|PyPi Package| |Build Status| |Coverage Report|
 
 python-stripzip
 ===============
@@ -31,8 +31,6 @@ See also
 
 .. |Build Status| image:: https://github.com/Code0x58/python-stripzip/actions/workflows/ci.yml/badge.svg?branch=master
    :target: https://github.com/Code0x58/python-stripzip/actions/workflows/ci.yml
-.. |Codacy Rating| image:: https://api.codacy.com/project/badge/Grade/7468a12faccb4c1497575d607b097ec6
-   :target: https://www.codacy.com/app/evilumbrella-github/python-stripzip?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Code0x58/python-stripzip&amp;utm_campaign=Badge_Grade
 .. |PyPi Package| image:: https://badge.fury.io/py/python-stripzip.svg
    :target: https://pypi.org/project/python-stripzip/
 .. |Coverage Report| image:: https://codecov.io/gh/Code0x58/python-stripzip/branch/master/graph/badge.svg


### PR DESCRIPTION
## Summary
- remove the Codacy badge from the README to drop the service

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919eb4a670483229cc35ff7dbbf8626)