### PR TITLE
Fix CI Codecov upload secret access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    environment: pypi
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:


### PR DESCRIPTION
## Summary
- ensure the CI tests job targets the `pypi` environment so the `CODECOV_TOKEN` secret is available and the Codecov upload step can run

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ecf08fec8322be212672fa53e821)