### PR TITLE
Ensure Codecov uploads run despite test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,21 @@ jobs:
           pip install . pytest pytest-cov
 
       - name: Run tests
-        run: pytest -vv --cov=stripzip --cov-report=xml
+        run: pytest -vv --cov=stripzip --cov-report=xml --junitxml=test-results.xml
 
       - name: Upload coverage to Codecov
-        if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v4
+        if: always() && env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage.xml
+          fail_ci_if_error: true
+
+      - name: Upload test results to Codecov
+        if: always() && env.CODECOV_TOKEN != ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ env.CODECOV_TOKEN }}
+          files: ./test-results.xml
+          report_type: test_results
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- adjust the Codecov upload steps so they run even if the preceding test step fails, ensuring both coverage and test-result artifacts still get pushed whenever a token is configured

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919eefb3cfc83228a04972bb7137a32)